### PR TITLE
Fixed a warning reported by Veracode security scan:

### DIFF
--- a/Cupcake/Color.swift
+++ b/Cupcake/Color.swift
@@ -69,9 +69,21 @@ public func Color(_ any: Any?) -> UIColor? {
         }
         
         if string == "random" {
-            r = Int(arc4random_uniform(256))
-            g = Int(arc4random_uniform(256))
-            b = Int(arc4random_uniform(256))
+            // generate cryptographically secure random bytes
+            // avoid warnings reported by security scans like Veracode
+            // https://developer.apple.com/documentation/security/1399291-secrandomcopybytes
+            
+            var bytes = [UInt8](repeating: 0, count: 3)
+            let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+            if status == errSecSuccess {
+                r = Int(bytes[0])
+                g = Int(bytes[1])
+                b = Int(bytes[2])
+            } else {
+                r = 0
+                g = 0
+                b = 0
+            }
             
         } else if string.hasPrefix("#") {
             if string.cpk_length() == 4 {


### PR DESCRIPTION
"Insufficient Entropy (CWE ID 331)(3 flaws):
Description:
Standard random number generators do not provide a sufficient amount of entropy when used for security purposes. Attackers can brute force the output of pseudorandom number generators such as rand(). If this random number is used where security is a concern, such as generating a session identifier or cryptographic key, use a trusted cryptographic random number generator instead.
Location:
- Color.swift 72
- Color.swift 73
- Color.swift 74"